### PR TITLE
Fix document upload File metadata handling

### DIFF
--- a/src/components/DocumentUpload.tsx
+++ b/src/components/DocumentUpload.tsx
@@ -36,13 +36,17 @@ const DocumentUpload = ({ caseId, onDocumentUploaded }: DocumentUploadProps) => 
       lastModified: f.lastModified
     })));
     
-    const newFiles: UploadFile[] = acceptedFiles.map(file => ({
-      ...file,
-      id: Math.random().toString(36).substr(2, 9),
-      category: 'medical',
-      progress: 0,
-      status: 'pending'
-    }));
+    const newFiles: UploadFile[] = acceptedFiles.map(file => {
+      // Preserve the original File prototype so we retain browser File APIs
+      const fileWithMeta = Object.assign(file, {
+        id: Math.random().toString(36).substr(2, 9),
+        category: 'medical',
+        progress: 0,
+        status: 'pending' as UploadFile['status']
+      });
+
+      return fileWithMeta as UploadFile;
+    });
     
     setFiles(prev => [...prev, ...newFiles]);
   }, []);


### PR DESCRIPTION
## Summary
- preserve the native File prototype when augmenting dropped files so browser File APIs remain available during upload processing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df8f92ac1083249990e48e6c2a9b01