### PR TITLE
Ensure uploaded PDFs remain viewable

### DIFF
--- a/src/components/DocumentUpload.tsx
+++ b/src/components/DocumentUpload.tsx
@@ -24,6 +24,15 @@ interface UploadFile extends File {
   error?: string;
 }
 
+const readFileAsDataUrl = (file: File) => {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+};
+
 const DocumentUpload = ({ caseId, onDocumentUploaded }: DocumentUploadProps) => {
   const [files, setFiles] = useState<UploadFile[]>([]);
   const [isUploading, setIsUploading] = useState(false);
@@ -36,13 +45,17 @@ const DocumentUpload = ({ caseId, onDocumentUploaded }: DocumentUploadProps) => 
       lastModified: f.lastModified
     })));
     
-    const newFiles: UploadFile[] = acceptedFiles.map(file => ({
-      ...file,
-      id: Math.random().toString(36).substr(2, 9),
-      category: 'medical',
-      progress: 0,
-      status: 'pending'
-    }));
+    const newFiles: UploadFile[] = acceptedFiles.map(file => {
+      // Preserve the original File prototype so we retain browser File APIs
+      const fileWithMeta = Object.assign(file, {
+        id: Math.random().toString(36).substr(2, 9),
+        category: 'medical',
+        progress: 0,
+        status: 'pending' as UploadFile['status']
+      });
+
+      return fileWithMeta as UploadFile;
+    });
     
     setFiles(prev => [...prev, ...newFiles]);
   }, []);
@@ -126,15 +139,25 @@ const DocumentUpload = ({ caseId, onDocumentUploaded }: DocumentUploadProps) => 
         pageCount: processedDoc.pageCount,
         detectedType: processedDoc.detectedType
       });
-      
+
       updateFileStatus(file.id, { progress: 75 });
 
       // Get current user info
       const currentUser = authService.getCurrentUser();
-      
+
       // Create document record with proper type and size calculation
       const sizeInKB = fileSize > 0 ? (fileSize / 1024).toFixed(2) : '0.00';
-      
+
+      let fileDataUrl = processedDoc.fileDataUrl;
+      if (!fileDataUrl) {
+        try {
+          fileDataUrl = await readFileAsDataUrl(file);
+          console.log('Generated file data URL locally because processor did not return one');
+        } catch (readError) {
+          console.warn('Unable to create data URL for file:', readError);
+        }
+      }
+
       const document: Document = {
         id: `doc_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
         name: fileName, // Use the actual file name
@@ -144,11 +167,12 @@ const DocumentUpload = ({ caseId, onDocumentUploaded }: DocumentUploadProps) => 
         uploadedById: currentUser?.id || '1',
         size: `${sizeInKB} KB`,
         pages: processedDoc.pageCount || 1,
-        category: file.category as any,
+        category: file.category,
         caseId: caseId,
         filePath: `documents/${caseId}/${fileName}`,
         content: processedDoc.content,
-        fileUrl: processedDoc.imageDataUrl // For PDF preview images and other file URLs
+        fileUrl: fileDataUrl,
+        previewImageUrl: processedDoc.previewImageUrl || processedDoc.imageDataUrl
       };
 
       console.log('Saving document to dataService:', {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,7 +76,8 @@ export interface Document {
   category: string;
   caseId: string;
   filePath: string;
-  fileUrl?: string; // optional file URL for viewing
+  fileUrl?: string; // optional file URL for viewing/downloading the original document
+  previewImageUrl?: string; // optional preview image (e.g. rendered PDF page or image thumbnail)
   content?: string; // extracted text for AI processing
 }
 


### PR DESCRIPTION
## Summary
- ensure uploaded documents keep an embeddable data URL even when preview generation does not supply one
- make the document viewer gracefully fall back to the original PDF when preview rendering fails and expose a manual open link
- feed pdf.js a typed array to improve compatibility when processing PDF uploads

## Testing
- npm run lint (fails due to existing lint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68df8f92ac1083249990e48e6c2a9b01