### PR TITLE
Handle missing documentId in viewer hook

### DIFF
--- a/src/hooks/useDocumentViewer.ts
+++ b/src/hooks/useDocumentViewer.ts
@@ -10,15 +10,17 @@ export const useDocumentViewer = () => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (documentId) {
-      const documents = dataService.getDocuments();
-      const foundDocument = documents.find(d => d.id === documentId);
-      console.log("Looking for document:", documentId, "Found:", foundDocument);
-      if (foundDocument) {
-        setDocument(foundDocument);
-      }
+    if (!documentId) {
+      setDocument(null);
       setLoading(false);
+      return;
     }
+
+    setLoading(true);
+    const documents = dataService.getDocuments();
+    const foundDocument = documents.find(d => d.id === documentId) ?? null;
+    setDocument(foundDocument);
+    setLoading(false);
   }, [documentId]);
 
   return { document, loading };


### PR DESCRIPTION
## Summary
- ensure the document viewer hook gracefully handles absent document IDs
- clear the loading state and remove the debug log when no matching document is found

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfd00d65288324a7915135341635b1