### PR TITLE
Add browser guards and lazy data service access

### DIFF
--- a/src/components/DocumentList.tsx
+++ b/src/components/DocumentList.tsx
@@ -6,7 +6,7 @@ import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { Search, FileText, Download, Eye, Trash2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
-import { dataService } from "@/services/dataService";
+import { getDataService } from "@/services/dataService";
 import { authService } from "@/services/authService";
 import { Document, User } from "@/types";
 
@@ -22,6 +22,12 @@ const DocumentList = ({ caseId }: DocumentListProps) => {
 
   const loadDocuments = useCallback(() => {
     try {
+      const dataService = getDataService();
+      if (!dataService) {
+        setDocuments([]);
+        return;
+      }
+
       const caseDocuments = dataService.getDocuments().filter(doc => doc.caseId === caseId);
       console.log(`Loading documents for case: ${caseId} Found: ${caseDocuments.length}`);
       setDocuments(caseDocuments);
@@ -44,6 +50,12 @@ const DocumentList = ({ caseId }: DocumentListProps) => {
   const handleDeleteDocument = (documentId: string) => {
     if (currentUser?.role === 'admin') {
       try {
+        const dataService = getDataService();
+        if (!dataService) {
+          console.warn('DataService is not available in the current environment.');
+          return;
+        }
+
         dataService.deleteDocument(documentId);
         loadDocuments(); // Refresh the list
         

--- a/src/components/DocumentUpload.tsx
+++ b/src/components/DocumentUpload.tsx
@@ -7,7 +7,7 @@ import { Progress } from "@/components/ui/progress";
 import { Upload, FileText, X, CheckCircle, AlertCircle } from "lucide-react";
 import { toast } from "sonner";
 import { Document } from "@/types";
-import { dataService } from "@/services/dataService";
+import { getDataService } from "@/services/dataService";
 import { DocumentProcessor } from "@/utils/documentProcessor";
 import { authService } from "@/services/authService";
 
@@ -112,6 +112,11 @@ const DocumentUpload = ({ caseId, onDocumentUploaded }: DocumentUploadProps) => 
 
   const processAndUploadFile = async (file: UploadFile) => {
     try {
+      const dataService = getDataService();
+      if (!dataService) {
+        throw new Error('Document storage is unavailable in the current environment.');
+      }
+
       // Validate file first - make sure we have valid file properties
       if (!file || !file.name || file.size === 0) {
         throw new Error('Invalid file: missing name or empty file');
@@ -181,7 +186,7 @@ const DocumentUpload = ({ caseId, onDocumentUploaded }: DocumentUploadProps) => 
         type: document.type,
         size: document.size
       });
-      
+
       // Save to data service
       dataService.addDocument(document);
       

--- a/src/hooks/useDocumentUpload.ts
+++ b/src/hooks/useDocumentUpload.ts
@@ -2,7 +2,7 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { Document } from "@/types";
-import { dataService } from "@/services/dataService";
+import { getDataService } from "@/services/dataService";
 import { authService } from "@/services/authService";
 import { validateFiles } from "@/utils/fileValidation";
 import { readFileContent } from "@/utils/documentContent";
@@ -73,8 +73,14 @@ export const useDocumentUpload = (caseId: string, onDocumentUploaded?: (newDocum
     }
 
     setUploading(true);
-    
+
     try {
+      const dataService = getDataService();
+      if (!dataService) {
+        toast.error("Document storage is unavailable in the current environment.");
+        return;
+      }
+
       await new Promise(resolve => setTimeout(resolve, 1500));
       
       const uploadedDocuments: Document[] = [];

--- a/src/hooks/useDocumentViewer.ts
+++ b/src/hooks/useDocumentViewer.ts
@@ -1,7 +1,7 @@
 
 import { useState, useEffect } from "react";
 import { useParams } from "react-router-dom";
-import { dataService } from "@/services/dataService";
+import { getDataService } from "@/services/dataService";
 import { Document } from "@/types";
 
 export const useDocumentViewer = () => {
@@ -17,6 +17,13 @@ export const useDocumentViewer = () => {
     }
 
     setLoading(true);
+    const dataService = getDataService();
+    if (!dataService) {
+      setDocument(null);
+      setLoading(false);
+      return;
+    }
+
     const documents = dataService.getDocuments();
     const foundDocument = documents.find(d => d.id === documentId) ?? null;
     setDocument(foundDocument);

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -21,7 +21,7 @@ import ChatPanel from "@/components/ChatPanel";
 import CaseAssignment from "@/components/CaseAssignment";
 import { authService } from "@/services/authService";
 import { chatService } from "@/services/chatService";
-import { dataService } from "@/services/dataService";
+import { getDataService } from "@/services/dataService";
 import { PatientCase, Document, User, ActivityLog } from "@/types";
 import { toast } from "sonner";
 
@@ -39,6 +39,14 @@ const AdminDashboard = () => {
   const [documents, setDocuments] = useState<Document[]>([]);
   const [activityLogs, setActivityLogs] = useState<ActivityLog[]>([]);
 
+  const getService = () => {
+    const service = getDataService();
+    if (!service) {
+      console.warn('DataService is not available in the current environment.');
+    }
+    return service;
+  };
+
   useEffect(() => {
     const user = authService.getCurrentUser();
     if (!user || user.role !== 'admin') {
@@ -51,6 +59,14 @@ const AdminDashboard = () => {
   }, [navigate]);
 
   const loadInitialData = () => {
+    const dataService = getService();
+    if (!dataService) {
+      setCases([]);
+      setDocuments([]);
+      setActivityLogs([]);
+      return;
+    }
+
     setCases(dataService.getCases());
     setDocuments(dataService.getDocuments());
     setActivityLogs(dataService.getActivityLogs());
@@ -64,6 +80,12 @@ const AdminDashboard = () => {
   };
 
   const handleCaseUpdate = (updatedCase: PatientCase) => {
+    const dataService = getService();
+    if (!dataService) {
+      toast.error("Data storage is unavailable in the current environment.");
+      return;
+    }
+
     dataService.updateCase(updatedCase);
     setCases(dataService.getCases());
 
@@ -89,6 +111,12 @@ const AdminDashboard = () => {
 
   const handleCaseDelete = (caseId: string) => {
     const caseToDelete = cases.find(c => c.id === caseId);
+    const dataService = getService();
+    if (!dataService) {
+      toast.error("Data storage is unavailable in the current environment.");
+      return;
+    }
+
     dataService.deleteCase(caseId);
     setCases(dataService.getCases());
     setDocuments(dataService.getDocuments().filter(doc => doc.caseId !== caseId));
@@ -122,7 +150,13 @@ const AdminDashboard = () => {
       adminId: currentUser?.id || '',
       adminAssigned: currentUser?.name || ''
     };
-    
+
+    const dataService = getService();
+    if (!dataService) {
+      toast.error("Data storage is unavailable in the current environment.");
+      return;
+    }
+
     dataService.addCase(caseWithMetadata);
     setCases(dataService.getCases());
 
@@ -157,7 +191,13 @@ const AdminDashboard = () => {
       uploadedById: currentUser?.id || '',
       uploadedBy: currentUser?.name || ''
     };
-    
+
+    const dataService = getService();
+    if (!dataService) {
+      toast.error("Data storage is unavailable in the current environment.");
+      return;
+    }
+
     dataService.addDocument(documentWithMetadata);
     setDocuments(dataService.getDocuments());
     
@@ -201,6 +241,12 @@ const AdminDashboard = () => {
   const handleDocumentDeleted = (documentId: string) => {
     const doc = documents.find(d => d.id === documentId);
     if (doc) {
+      const dataService = getService();
+      if (!dataService) {
+        toast.error("Data storage is unavailable in the current environment.");
+        return;
+      }
+
       dataService.deleteDocument(documentId);
       setDocuments(dataService.getDocuments());
       

--- a/src/pages/CaseDetails.tsx
+++ b/src/pages/CaseDetails.tsx
@@ -9,7 +9,7 @@ import AIDocumentChat from "@/components/AIDocumentChat";
 import DocumentList from "@/components/DocumentList";
 import DocumentUpload from "@/components/DocumentUpload";
 import EvaluationForm from "@/components/EvaluationForm";
-import { dataService } from "@/services/dataService";
+import { getDataService } from "@/services/dataService";
 import { authService } from "@/services/authService";
 import { PatientCase, User, Document } from "@/types";
 
@@ -23,6 +23,12 @@ const CaseDetails = () => {
 
   const loadDocuments = useCallback(() => {
     if (caseId) {
+      const dataService = getDataService();
+      if (!dataService) {
+        setDocuments([]);
+        return;
+      }
+
       const caseDocuments = dataService.getDocuments().filter(doc => doc.caseId === caseId);
       setDocuments(caseDocuments);
     }
@@ -37,6 +43,11 @@ const CaseDetails = () => {
     setCurrentUser(user);
 
     if (caseId) {
+      const dataService = getDataService();
+      if (!dataService) {
+        return;
+      }
+
       const cases = dataService.getCases();
       const foundCase = cases.find(c => c.id === caseId);
       if (foundCase) {

--- a/src/pages/SystemAdminDashboard.tsx
+++ b/src/pages/SystemAdminDashboard.tsx
@@ -12,7 +12,7 @@ import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Settings, FileText, Users, Activity, Plus, Edit, Trash2 } from "lucide-react";
 import { authService } from "@/services/authService";
-import { dataService } from "@/services/dataService";
+import { getDataService } from "@/services/dataService";
 import { User, AIRule } from "@/types";
 import { toast } from "sonner";
 import UserManagement from "@/components/UserManagement";
@@ -29,6 +29,14 @@ const SystemAdminDashboard = () => {
     category: 'medical' as string
   });
 
+  const getService = () => {
+    const service = getDataService();
+    if (!service) {
+      console.warn('DataService is not available in the current environment.');
+    }
+    return service;
+  };
+
   useEffect(() => {
     const user = authService.getCurrentUser();
     if (!user || user.role !== 'system-admin') {
@@ -40,6 +48,12 @@ const SystemAdminDashboard = () => {
   }, [navigate]);
 
   const loadAIRules = () => {
+    const dataService = getService();
+    if (!dataService) {
+      setAiRules([]);
+      return;
+    }
+
     const rules = dataService.getAIRules();
     setAiRules(rules);
   };
@@ -59,6 +73,12 @@ const SystemAdminDashboard = () => {
       createdBy: currentUser?.id || '',
       updatedAt: new Date().toISOString()
     };
+
+    const dataService = getService();
+    if (!dataService) {
+      toast.error("Data storage is unavailable in the current environment.");
+      return;
+    }
 
     dataService.addAIRule(rule);
     loadAIRules();
@@ -90,6 +110,12 @@ const SystemAdminDashboard = () => {
       updatedAt: new Date().toISOString()
     };
 
+    const dataService = getService();
+    if (!dataService) {
+      toast.error("Data storage is unavailable in the current environment.");
+      return;
+    }
+
     dataService.updateAIRule(updatedRule);
     loadAIRules();
     setEditingRule(null);
@@ -98,6 +124,12 @@ const SystemAdminDashboard = () => {
   };
 
   const handleDeleteRule = (ruleId: string) => {
+    const dataService = getService();
+    if (!dataService) {
+      toast.error("Data storage is unavailable in the current environment.");
+      return;
+    }
+
     dataService.deleteAIRule(ruleId);
     loadAIRules();
     toast.success("AI rule deleted successfully");
@@ -111,6 +143,12 @@ const SystemAdminDashboard = () => {
         isActive: !rule.isActive,
         updatedAt: new Date().toISOString()
       };
+      const dataService = getService();
+      if (!dataService) {
+        toast.error("Data storage is unavailable in the current environment.");
+        return;
+      }
+
       dataService.updateAIRule(updatedRule);
       loadAIRules();
       toast.success("AI rule updated successfully");

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,11 +1,24 @@
 import { User, ActivityLog, PatientCase } from '../types';
-import { dataService } from './dataService';
+import { getDataService } from './dataService';
 
 class AuthService {
   private currentUser: User | null = null;
 
+  private getService() {
+    const service = getDataService();
+    if (!service) {
+      console.warn('DataService is not available in the current environment.');
+    }
+    return service;
+  }
+
   login(email: string, password: string): User | null {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return null;
+      }
+
       const users = dataService.getUsers();
       console.log('Attempting login with:', email, 'Available users:', users.map(u => ({ email: u.email, role: u.role, isActive: u.isActive })));
       
@@ -38,6 +51,11 @@ class AuthService {
 
   getAllUsers(): User[] {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return [];
+      }
+
       return dataService.getUsers();
     } catch (error) {
       console.error('Error getting all users:', error);
@@ -47,6 +65,11 @@ class AuthService {
 
   getDoctors(): User[] {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return [];
+      }
+
       return dataService.getUsers().filter(u => u.role === 'doctor' && u.isActive);
     } catch (error) {
       console.error('Error getting doctors:', error);
@@ -56,6 +79,11 @@ class AuthService {
 
   getAdmins(): User[] {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return [];
+      }
+
       return dataService.getUsers().filter(u => u.role === 'admin' && u.isActive);
     } catch (error) {
       console.error('Error getting admins:', error);
@@ -65,6 +93,11 @@ class AuthService {
 
   createUser(userData: Omit<User, 'id' | 'createdAt'> & { password: string }): User {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        throw new Error('DataService is not available.');
+      }
+
       const newUser: User = {
         ...userData,
         id: Date.now().toString(),
@@ -93,6 +126,11 @@ class AuthService {
 
   updateUser(userData: User): void {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return;
+      }
+
       dataService.updateUser(userData);
     } catch (error) {
       console.error('Error updating user:', error);
@@ -101,6 +139,11 @@ class AuthService {
 
   deactivateUser(userId: string): void {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return;
+      }
+
       const users = dataService.getUsers();
       const user = users.find(u => u.id === userId);
       if (user) {
@@ -139,6 +182,11 @@ class AuthService {
   // Case management methods
   getAllCases(): PatientCase[] {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return [];
+      }
+
       return dataService.getCases();
     } catch (error) {
       console.error('Error getting all cases:', error);
@@ -148,6 +196,11 @@ class AuthService {
 
   getCasesForDoctor(doctorId: string): PatientCase[] {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return [];
+      }
+
       // Enhanced filtering to catch all possible assignment scenarios
       const allCases = dataService.getCases();
       const doctorCases = allCases.filter(case_ => {
@@ -178,6 +231,11 @@ class AuthService {
 
   addCase(case_: PatientCase): void {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return;
+      }
+
       dataService.addCase(case_);
       
       if (this.currentUser) {
@@ -198,6 +256,11 @@ class AuthService {
 
   updateCase(updatedCase: PatientCase): void {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return;
+      }
+
       updatedCase.lastUpdated = new Date().toISOString();
       dataService.updateCase(updatedCase);
       
@@ -219,9 +282,14 @@ class AuthService {
 
   deleteCase(caseId: string): void {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return;
+      }
+
       const cases = dataService.getCases();
       const case_ = cases.find(c => c.id === caseId);
-      
+
       dataService.deleteCase(caseId);
       
       if (this.currentUser && case_) {
@@ -242,6 +310,11 @@ class AuthService {
 
   assignCaseToDoctor(caseId: string, doctorId: string): void {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return;
+      }
+
       const cases = dataService.getCases();
       const users = dataService.getUsers();
       const case_ = cases.find(c => c.id === caseId);
@@ -294,6 +367,11 @@ class AuthService {
         details: details || '',
         ipAddress: '127.0.0.1'
       };
+      const dataService = this.getService();
+      if (!dataService) {
+        return;
+      }
+
       dataService.addActivityLog(log);
     } catch (error) {
       console.error('Error logging activity:', error);
@@ -302,6 +380,11 @@ class AuthService {
 
   getActivityLogs(): ActivityLog[] {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return [];
+      }
+
       return dataService.getActivityLogs().sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
     } catch (error) {
       console.error('Error getting activity logs:', error);
@@ -311,6 +394,11 @@ class AuthService {
 
   getUserActivityLogs(userId: string): ActivityLog[] {
     try {
+      const dataService = this.getService();
+      if (!dataService) {
+        return [];
+      }
+
       return dataService.getActivityLogs()
         .filter(log => log.userId === userId)
         .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());


### PR DESCRIPTION
## Summary
- add a browser guard to the data service and expose a lazy accessor to prevent SSR usage
- update dependent services, hooks, and UI to use the accessor with null-safe fallbacks
- harden the data management tools so they behave sensibly when storage is unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfdb0437d4832484d10ba25bff2751